### PR TITLE
Add ISO14443B support for LIBNFC, mrpkey.py, isotype.py & multiselect.py

### DIFF
--- a/isotype.py
+++ b/isotype.py
@@ -76,11 +76,15 @@ if card.readertype == card.READER_PCSC:
 		print card.ISO7816ErrorCodes[card.errorcode]
 		os._exit(True)
 if card.readertype == card.READER_LIBNFC:
-	if card.select():
+	if card.select('A'):
 		print '     ID: ' + card.uid
 		if card.atr:
 			print '     ATS: ' + card.atr
 		print "       Tag is ISO 14443A"
+		typed= True
+	if card.select('B'):
+		print '   PUPI: ' + card.pupi
+		print "       Tag is ISO 14443B"
 		typed= True
 if not typed:
 	print "Could not determine type"

--- a/mrpkey.py
+++ b/mrpkey.py
@@ -1083,7 +1083,7 @@ if arg0 == 'UNSETBAC':
 	UNSETBAC= True
 
 if arg0 == 'CHECK':
-	while not passport.hsselect('08'):
+	while not passport.hsselect('08', 'A') and not passport.hsselect('08', 'B'):
 		print 'Waiting for passport... (%s)' % passport.errorcode
 	if passport.iso_7816_select_file(passport.AID_MRTD,passport.ISO_7816_SELECT_BY_NAME,'0C'):
 		print 'Device is a Machine Readable Document'
@@ -1112,7 +1112,7 @@ if not FILES and not TEST:
 	# 02 = 212 kBaud
 	# 04 = 414 kBaud
 	# 08 = 818 kBaud
-	while not passport.hsselect('08'):
+	while not passport.hsselect('08', 'A') and not passport.hsselect('08', 'B'):
 		print 'Waiting for passport... (%s)' % passport.errorcode
 	print 'Device set to %s transfers' % passport.ISO_SPEED[passport.speed]
 	print 'Device supports %s Byte transfers' % passport.ISO_FRAMESIZE[passport.framesize]
@@ -1433,7 +1433,7 @@ if Jmrtd:
 		filespath=tempfiles
 		print
 		raw_input('Please replace passport with a JMRTD or vonJeek emulator card and press ENTER when ready...')
-	if not passport.hsselect('08') or not passport.iso_7816_select_file(passport.AID_MRTD,passport.ISO_7816_SELECT_BY_NAME,'0C'):
+	if (not passport.hsselect('08', 'A') and not passport.hsselect('08', 'B')) or not passport.iso_7816_select_file(passport.AID_MRTD,passport.ISO_7816_SELECT_BY_NAME,'0C'):
 		print "Couldn't select JMRTD!"
 		os._exit(True)
 	print "Initialising JMRTD or vonJeek..."

--- a/multiselect.py
+++ b/multiselect.py
@@ -46,7 +46,7 @@ else:
         card.settagtype(card.ALL)
 
 while 42:
-	if card.select():
+	if card.select('A') or card.select('B'):
 		print '    Tag ID: ' + card.uid,
 		if (card.readertype == card.READER_ACG and string.find(card.readername,"LFX") == 0):
 			print "    Tag Type:" + card.LFXTags[card.tagtype]

--- a/rfidiot/RFIDIOt.py
+++ b/rfidiot/RFIDIOt.py
@@ -947,7 +947,7 @@ class rfidiot:
 				# do nothing
 				time.sleep(0.1)
 		return True
-	def select(self):
+	def select(self, cardtype='A'):
 		if self.DEBUG:
 			print 'in select'
 		self.uid= ''
@@ -1020,18 +1020,36 @@ class rfidiot:
 			try:
 				if self.DEBUG:
 					print 'selecting card using LIBNFC'
-				result = self.nfc.selectISO14443A()
-				if result:
-					self.atr = result.atr
-					self.uid = result.uid
-					if self.DEBUG:
-						print 'ATR: ' + self.atr
-						print 'UID: ' + self.uid
-					return True
+				if cardtype == 'A':
+					result = self.nfc.selectISO14443A()
+					if result:
+						self.atr = result.atr
+						self.uid = result.uid
+						if self.DEBUG:
+							print 'UID: ' + self.uid
+						return True
+					else:
+						if self.DEBUG:
+							print 'Error selecting card'
+						return False
 				else:
-					if self.DEBUG:
-						print 'Error selecting card'
-					return False
+					if cardtype == 'B':
+						result = self.nfc.selectISO14443B()
+						if result:
+							self.pupi = result.pupi
+							self.atr = result.atr
+							self.uid = result.uid
+							if self.DEBUG:
+								print 'PUPI: ' + self.pupi
+							return True
+						else:
+							if self.DEBUG:
+								print 'Error selecting card'
+							return False
+					else:
+						if self.DEBUG:
+							print 'Error: Unknown card type specified: %s' % cardtype
+						return False
 			except ValueError:
 				self.errorcode = 'Error selecting card using LIBNFC' + e
 		
@@ -1071,10 +1089,10 @@ class rfidiot:
 			self.errorcode= ret
 			return False
 		return True
-	def hsselect(self,speed):
+	def hsselect(self,speed,cardtype='A'):
 		if self.readertype == self.READER_PCSC or self.readertype == self.READER_LIBNFC or self.READER_ANDROID:
 			# low level takes care of this, so normal select only
-			if self.select():
+			if self.select(cardtype):
 				#fixme - find true speed/framesize
 				self.speed= '04'
 				self.framesize= '08'


### PR DESCRIPTION
Hi Adam,
First time I had a TypeB ePassport in my hands (a French one, with EAC & fingerprints).
I had to add support for typeB to RFIDIOt & mrpkey to be able to read it.
I tried to do it as cleanly as I could but maybe you want to change that.
Cheers
Phil
PS: I don't have the epp anymore so I cannot do other tests.
