### PR TITLE
Adding JEWEL support to isotype.py and pynfc.py

### DIFF
--- a/isotype.py
+++ b/isotype.py
@@ -89,6 +89,11 @@ if card.readertype == card.READER_LIBNFC:
 		print '    CID: ' + card.cid
 		print "       Tag is ISO 14443B"
 		typed= True
+	if card.select('JEWEL'):
+		print 'SENSRES: ' + card.btsensres
+		print '     ID: ' + card.btid
+		print "       Tag is JEWEL"
+		typed= True
 if not typed:
 	print "Could not determine type"
 	os._exit(True)

--- a/rfidiot/RFIDIOt.py
+++ b/rfidiot/RFIDIOt.py
@@ -1060,32 +1060,45 @@ class rfidiot:
 						if self.DEBUG:
 							print 'Error selecting card'
 						return False
-				else:
-					if cardtype == 'B':
-						result = self.nfc.selectISO14443B()
-						if result:
-							self.pupi = result.pupi
-							self.atr = result.atr
-							self.uid = result.uid
-							self.appdata = result.appdata
-							self.protocol = result.protocol
-							self.cid = result.cid
-							if self.DEBUG:
-								print 'PUPI: ' + self.pupi
-								print 'ATR: ' + self.atr
-								print 'UID: ' + self.uid
-								print 'APPDATA: ' + self.appdata
-								print 'PROTOCOL: ' + self.protocol
-								print 'CID: ' + self.cid
-							return True
-						else:
-							if self.DEBUG:
-								print 'Error selecting card'
-							return False
+				elif cardtype == 'B':
+					result = self.nfc.selectISO14443B()
+					if result:
+						self.pupi = result.pupi
+						self.atr = result.atr
+						self.uid = result.uid
+						self.appdata = result.appdata
+						self.protocol = result.protocol
+						self.cid = result.cid
+						if self.DEBUG:
+							print 'PUPI: ' + self.pupi
+							print 'ATR: ' + self.atr
+							print 'UID: ' + self.uid
+							print 'APPDATA: ' + self.appdata
+							print 'PROTOCOL: ' + self.protocol
+							print 'CID: ' + self.cid
+						return True
 					else:
 						if self.DEBUG:
-							print 'Error: Unknown card type specified: %s' % cardtype
+							print 'Error selecting card'
 						return False
+				elif cardtype == 'JEWEL':
+					result = self.nfc.selectJEWEL()
+					if result:
+						self.btsensres = result.btSensRes
+						self.btid = result.btId
+						self.uid = result.uid
+						if self.DEBUG:
+							print 'SENSRES: ' + self.btsensres
+							print 'ID: ' + self.btid
+						return True
+					else:
+						if self.DEBUG:
+							print 'Error selecting card'
+						return False
+				else:
+					if self.DEBUG:
+						print 'Error: Unknown card type specified: %s' % cardtype
+					return False
 			except ValueError:
 				self.errorcode = 'Error selecting card using LIBNFC' + e
 		

--- a/rfidiot/pynfc.py
+++ b/rfidiot/pynfc.py
@@ -253,6 +253,17 @@ class ISO14443B(object):
 		rv = "ISO14443B(pupi='%s')" % (self.pupi)
 		return rv
 
+class JEWEL(object):
+	def __init__(self, ti):
+		self.btSensRes = "".join(["%02X" % x for x in ti.btSensRes[:2]])
+		self.btId = "".join(["%02X" % x for x in ti.btId[:4]])
+		self.uid = self.btId
+		self.atr = ""        # idem
+	
+	def __str__(self):
+		rv = "JEWEL(btSensRes='%s', btId='%s')" % (self.btSensRes, self.btId)
+		return rv
+
 class NFC(object):
 	def __init__(self, nfcreader):
 		self.LIB = ctypes.util.find_library('nfc')
@@ -424,6 +435,20 @@ class NFC(object):
 		nm.nbr = NBR_106
 		if self.libnfc.nfc_initiator_list_passive_targets(self.device, nm, ctypes.byref(target), MAX_TARGET_COUNT):
 			return ISO14443B(target[0].nti.nbi)
+		return None
+
+	def selectJEWEL(self):
+		"""Detect and initialise a JEWEL card, returns a JEWEL() object."""
+		if rfidiotglobals.Debug:
+			self.log.debug("Polling for JEWEL cards")
+		self.powerOff()
+		self.powerOn()
+		nm= NFC_MODULATION()
+		target= (NFC_TARGET * MAX_TARGET_COUNT) ()
+		nm.nmt = NMT_JEWEL
+		nm.nbr = NBR_106
+		if self.libnfc.nfc_initiator_list_passive_targets(self.device, nm, ctypes.byref(target), MAX_TARGET_COUNT):
+			return JEWEL(target[0].nti.nji)
 		return None
 
 	# set Mifare specific parameters


### PR DESCRIPTION
http://rfidiot.org/documentation.html lists Innovision Jewel tag support:

> isotype.py
> 
> Readers: ACG HF, ACG LAHF, PCSC
> TAGS: ISO 14443 A/B, ISO 15693, ISO 18000-3, NFC, I-CODE, HID iCLASS, FeliCa, Innovision Jewel, Mifare, JCOP
> 
> Attempt to determine HF TAG type and, where appropriate, show ATR/ATS values.

but no such support is actually available in RFIDIOt when using LIBNFC.  This adds support for detecting Jewel tags.